### PR TITLE
Fix: Clock not running.

### DIFF
--- a/sample/src/js/components/clock.html
+++ b/sample/src/js/components/clock.html
@@ -92,7 +92,7 @@
 
 			interval = setInterval( function () {
 				self.set( 'date', new Date() );
-			});
+			}, 900);
 
 			this.on( 'teardown', function () {
 				clearInterval( interval );


### PR DESCRIPTION
setInterval() requires a second parameter. 900ms is a good interval here. Setting the interval to exactly 1000ms would occasionally skip a second due to timing irregularities.