### PR TITLE
Fix:update rcu version to 0.4.2(previous version's base64Encode is broken)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rvc",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "RequireJS plugin to load and optimise Ractive components",
   "main": "rvc.js",
   "repository": {
@@ -24,7 +24,7 @@
     "gobble-babel": "^4.0.1",
     "gobble-cli": "^0.3.5",
     "gobble-esperanto-bundle": "^0.1.7",
-    "rcu": "^0.4.0",
+    "rcu": "^0.4.2",
     "requirejs": "^2.1.16",
     "resolve": "^1.1.6",
     "tosource": "~0.1.1"


### PR DESCRIPTION
Current version's rcu's internal method `base64Encode`  is broken.
I have noticed that it has been fixed since 0.4.1.

code from rcu v0.4.2
```js
  if ( typeof btoa === 'function' ) {
  	base64Encode = function ( str ) {
  		str = str.replace( /[^\x00-\x7F]/g, function ( char ) {
  			var hex = char.charCodeAt( 0 ).toString( 16 );
  			while ( hex.length < 4 ) hex = '0' + hex;

  			return '\\u' + hex;
  		});

  		return btoa( str );
  	};
  } else if ( typeof Buffer === 'function' ) {
  	base64Encode = function ( str ) {
  		return new Buffer( str, 'utf-8' ).toString( 'base64' );
  	};
  } else {
  	base64Encode = function () {};
  }
```
code from rcu v0.4.0
```js
  if ( typeof btoa === 'function' ) {
  	base64Encode = btoa;
  } else if ( typeof Buffer === 'function' ) {
  	base64Encode = function ( str ) {
  		return new Buffer( str, 'utf-8' ).toString( 'base64' );
  	};
  } else {
  	base64Encode = function () {};
  }
```